### PR TITLE
add SessionStart hook for bash permission-trigger guidance

### DIFF
--- a/plugins/mr-sparkle/.claude-plugin/plugin.json
+++ b/plugins/mr-sparkle/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "mr-sparkle",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Clean code - linting, formatting, documentation style, and scripting conventions."
 }

--- a/plugins/mr-sparkle/hooks/bash_guidance.sh
+++ b/plugins/mr-sparkle/hooks/bash_guidance.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# SessionStart hook - Proactive guidance for Bash patterns that trigger permission prompts
+#
+# Companion to block_unneeded_permission_triggers.sh (PreToolUse), which reactively blocks
+# these patterns. This hook proactively tells Claude what to avoid so it doesn't waste a
+# tool call getting blocked.
+#
+# KEEP IN SYNC: If you add/remove a pattern in block_unneeded_permission_triggers.sh,
+# update the guidance here too.
+
+cat <<'GUIDANCE'
+When writing Bash commands, avoid these patterns that trigger unnecessary permission prompts:
+- No `$()` or backtick command substitution — use pipes, temp variables, or separate commands
+- No output redirection (`>`, `2>&1`, `2>/dev/null`) — use separate commands or pipe to tools
+- No inline JSON with braces+quotes (`{"`, `'}`) — write JSON to a temp file instead
+- No `git -C <path>` — run git from the working directory
+- No `echo/printf "---..."` — dashes in quoted strings trigger flag-name detection
+- Use relative paths (`./script.py`), not fully qualified (`$PWD/script.py`)
+GUIDANCE

--- a/plugins/mr-sparkle/hooks/block_unneeded_permission_triggers.sh
+++ b/plugins/mr-sparkle/hooks/block_unneeded_permission_triggers.sh
@@ -7,6 +7,9 @@
 #
 # This is disruptive as a user; I have already granted approval.  Don't do things in dumb ways that make
 # me need to re-grant it.
+#
+# KEEP IN SYNC: bash_guidance.sh (SessionStart) proactively tells Claude about these
+# rules. If you add/remove a pattern here, update the guidance there too.
 
 command=$(jq -r '.tool_input.command // empty')
 [[ -z "$command" ]] && exit 0

--- a/plugins/mr-sparkle/hooks/hooks.json
+++ b/plugins/mr-sparkle/hooks/hooks.json
@@ -1,5 +1,17 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/bash_guidance.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",


### PR DESCRIPTION
Add proactive SessionStart hook that tells Claude about bash patterns that trigger permission prompts. Cross-reference comments between bash_guidance.sh and block_unneeded_permission_triggers.sh. mr-sparkle 1.4.1 → 1.5.0